### PR TITLE
fix(registry): fix aurelia-materialize-bridge tools

### DIFF
--- a/registry/aurelia-materialize-bridge.json
+++ b/registry/aurelia-materialize-bridge.json
@@ -28,42 +28,7 @@
                         "jquery"
                     ],
                     "resources": [
-                        "breadcrumbs/breadcrumbs.css",
-                        "breadcrumbs/breadcrumbs.html",
-                        "card/card.css",
-                        "card/card.html",
-                        "carousel/carousel-item.html",
-                        "carousel/carousel.css",
-                        "carousel/carousel.html",
-                        "checkbox/checkbox.html",
-                        "chip/chip.css",
-                        "chip/chip.html",
-                        "collection/collection-header.css",
-                        "collection/collection-header.html",
-                        "collection/collection-item.css",
-                        "collection/collection-item.html",
-                        "collection/collection.html",
-                        "collection/md-collection-selector.css",
-                        "collection/md-collection-selector.html",
-                        "colors/md-colors.html",
-                        "dropdown/dropdown-element.html",
-                        "fab/fab.html",
-                        "file/file.html",
-                        "input/input.css",
-                        "input/input.html",
-                        "navbar/navbar.css",
-                        "navbar/navbar.html",
-                        "pagination/pagination.html",
-                        "progress/progress.html",
-                        "radio/radio.html",
-                        "range/range.css",
-                        "range/range.html",
-                        "sidenav/sidenav.css",
-                        "sidenav/sidenav.html",
-                        "slider/slider.css",
-                        "switch/switch.css",
-                        "switch/switch.html",
-                        "well/md-well.html"
+                        "**/*.{css,html}"
                     ]
                 }
             ]
@@ -75,7 +40,7 @@
     "scripts": {
         "install": [
             "au prepare-materialize",
-            "node node_modules/requirejs/bin/r.js -o tools/rbuild.js"
+            "node node_modules/requirejs/bin/r.js -o rbuild.js"
         ],
         "uninstall": [
 

--- a/tasks/prepare-materialize.js
+++ b/tasks/prepare-materialize.js
@@ -21,7 +21,7 @@ let taskFonts = () => {
 let taskTools = () => {
     // copy tools folder from ./node_modules/aurelia-materialize-bridge/<path> to /<dest>
     return gulp
-        .src(['./node_modules/aurelia-materialize-bridge/build/tools/*'])
+        .src(['./node_modules/aurelia-materialize-bridge/build/tools/*.js'])
         .pipe(
             gulp.dest('.')
         );

--- a/tasks/prepare-materialize.js
+++ b/tasks/prepare-materialize.js
@@ -21,9 +21,9 @@ let taskFonts = () => {
 let taskTools = () => {
     // copy tools folder from ./node_modules/aurelia-materialize-bridge/<path> to /<dest>
     return gulp
-        .src(['./node_modules/aurelia-materialize-bridge/tools/*'])
+        .src(['./node_modules/aurelia-materialize-bridge/build/tools/*'])
         .pipe(
-            gulp.dest('tools')
+            gulp.dest('.')
         );
 };
 


### PR DESCRIPTION
Fixed the registry and `prepare-materialize` task for aurelia-materialize bridge.
The build tools are expected to be in the root directory - only to make instructions easier to follow (saves a step).

It's probably better to start the scripts from a sub-directory. But this works as it is. 😃 
